### PR TITLE
Battery cell count & chemistry from settings or best-effort guess

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -36,7 +36,8 @@ Starting from the default values in `firmware/src/main.c`, increase _P_ (`RATE_P
 
 ## TBS Source One V5 5" - 2206 Motors at 4S
 
-THIS TUNE IS STILL UNDERGOING TESTING
+THIS TUNE IS STILL UNDERGOING TESTING!
+
 ```
 Angle rate: 800
 Acro rate: 1500 (861 dps)

--- a/firmware/src/adc.c
+++ b/firmware/src/adc.c
@@ -2,6 +2,7 @@
 #include "gpio.h"
 #include "util.h"
 #include "led.h"
+#include "settings.h"
 
 void adc_init() {
   // Set ADC12 clock source to sysclk
@@ -41,6 +42,9 @@ void adc_init() {
   ADC1->CR |= ADC_CR_ADSTART;
 }
 
-uint16_t adc_read() {
-  return ADC1->DR;
+uint16_t adc_read_mV() {
+  struct settings *settings = settings_get(); // convenience
+  // Multiply ADC reading with ADC coefficient
+  // (which is saved at * 100 its required value)
+  return ADC1->DR * (settings->adc_coefficient / 100.0f);
 }

--- a/firmware/src/adc.h
+++ b/firmware/src/adc.h
@@ -2,4 +2,4 @@
 #include <stdint.h>
 
 void adc_init();
-uint16_t adc_read_mV();
+uint32_t adc_read_mV();

--- a/firmware/src/adc.h
+++ b/firmware/src/adc.h
@@ -2,4 +2,4 @@
 #include <stdint.h>
 
 void adc_init();
-uint16_t adc_read();
+uint16_t adc_read_mV();

--- a/firmware/src/main.c
+++ b/firmware/src/main.c
@@ -157,7 +157,7 @@ int main(void) {
     // Each time the gyro has new data, we run the main control loop.
     if(gyro_ready()) {
       // Fetch settings and scale them to the appropriate units.
-      struct settings *settings = settings_get();
+      struct settings *settings = settings_get(); // convenience
       float angle_rate    = 0.01f     * settings->angle_rate;
       float acro_rate     = 0.01f     * settings->acro_rate;
       float p             = 0.001f    * settings->p;

--- a/firmware/src/msp.c
+++ b/firmware/src/msp.c
@@ -48,14 +48,6 @@ void send_msp_displayport_clear() {
 
 // Parts of this are borrowed from the QuickSilver firmware's source code
 uint8_t guess_battery_cell_count(uint8_t chemistry) {
-  // Get an average mV reading
-  int count = 0;
-  int vbatt_avg = 0;
-  while(count < 5000) {
-    vbatt_avg += adc_read_mV();
-    count++;
-  }; vbatt_avg = vbatt_avg / count;
-
   // A best-effort guess is best done from the midpoint of the
   // cell's voltage range, which depends on battery chemistry
   float v_cell_min;
@@ -69,8 +61,9 @@ uint8_t guess_battery_cell_count(uint8_t chemistry) {
 
   // Using average cell voltage and voltage range midpoint,
   // we're now able to make our guess with some confidence
+  uint32_t v_batt_curr = adc_read_mV();
   for(int i=6; i>0; i--) {
-    if((vbatt_avg / i) > (int)(v_cell_mid*1000)) {
+    if((v_batt_curr / i) > (uint32_t)(v_cell_mid*1000)) {
       return i;
     }
   }
@@ -80,8 +73,8 @@ uint8_t guess_battery_cell_count(uint8_t chemistry) {
 
 void send_msp_displayport_write() {
   // Prepare a MSP_DISPLAYPORT payload
-  uint8_t payload[19];
-  memset(payload, 0, 19);
+  uint8_t payload[20];
+  memset(payload, 0, 20);
   // Send the write string subcommand
   payload[0] = 3;
    // Row
@@ -110,7 +103,7 @@ void send_msp_displayport_write() {
     snprintf((char*)payload+4, 16, "%iS %d.%02dV", (uint8_t)cell_count, v, mv);
 
     // Send the payload
-    send_msp(182, payload, 19);
+    send_msp(182, payload, 20);
   }
 }
 

--- a/firmware/src/settings.c
+++ b/firmware/src/settings.c
@@ -25,7 +25,7 @@ void settings_default() {
     settings.motor2          = 0;     // Default disabled
     settings.motor3          = 0;     // Default disabled
     settings.motor4          = 0;     // Default disabled
-    settings.adc_coefficient = 1325; // 1325 for TBS Source One 5" PCB, 1470 for Toadie 3" PCB
+    settings.adc_coefficient = 1778;  // 1778 for Toadie 3" PCB (so 1776 for TBS Source One 5" PCB?)
     settings.cell_count      = 0;
     settings.chemistry       = 0;
     // Remove this if you add another setting; it's just to keep number

--- a/firmware/src/settings.c
+++ b/firmware/src/settings.c
@@ -89,14 +89,24 @@ void settings_save() {
 void settings_print() {
   // Print the settings to the USB serial port.
   usb_printf("\nVersion: %d\n", settings.version);
-  usb_printf("Angle rate: %d\nAcro rate: %d\n", settings.angle_rate, settings.acro_rate);
-  usb_printf("P: %d\nI: %d\nD: %d\n", settings.p, settings.i, settings.d);
-  usb_printf("Yaw P: %d\nYaw I: %d\n", settings.yaw_p, settings.yaw_i);
-  usb_printf("Expo: %d\nYaw expo: %d\n", settings.expo, settings.yaw_expo);
-  usb_printf("Throttle gain: %d\nThrottle min: %d\n", settings.throttle_gain, settings.throttle_min);
-  usb_printf("Motor direction: %d\n", settings.motor_direction);
-  usb_printf("Motor 1: %d\nMotor 2: %d\nMotor 3: %d\nMotor 4: %d\n", settings.motor1, settings.motor2, settings.motor3, settings.motor4);
-  usb_printf("Checksum: %d\n", settings.checksum);
+  usb_printf("Flash checksum: %d\n", settings.checksum);
+  usb_printf("Current ADC reading: %d (= %dmV)\n", ADC1->DR, adc_read_mV());
+  usb_printf("\nAngle rate (sR): %d\nAcro rate (sr): %d\n", settings.angle_rate, settings.acro_rate);
+  usb_printf("P (sp): %d\nI (si): %d\nD (sd): %d\n", settings.p, settings.i, settings.d);
+  usb_printf("Yaw P (sy): %d\nYaw I (sY): %d\n", settings.yaw_p, settings.yaw_i);
+  usb_printf("Expo (se): %d\nYaw expo (sE): %d\n", settings.expo, settings.yaw_expo);
+  usb_printf("Throttle gain (st): %d\nThrottle min (sT): %d\n", settings.throttle_gain, settings.throttle_min);
+  usb_printf("Motor direction (smd): %d\n", settings.motor_direction);
+  usb_printf("Motor 1 (sm1): %d\nMotor 2 (sm2): %d\nMotor 3 (sm3): %d\nMotor 4 (sm4): %d\n", settings.motor1, settings.motor2, settings.motor3, settings.motor4);
+  usb_printf("ADC calibration coefficient (sba): %d\n", settings.adc_coefficient);
+  usb_printf("Cell count (sbc; 0 = best-effort auto-detect): %d\n", settings.cell_count);
+  usb_printf("Battery chemistry (sbh; 0 = LiPo, 1 = LiHV, 2 = LiIon): %d\n", settings.chemistry);
+  usb_printf("\nw: Write settings\n");
+  usb_printf("r: (Re)read settings\n");
+  usb_printf("d: Restore defaults\n");
+  usb_printf("e: Erase flash\n");
+  usb_printf("h: Dump flash\n");
+  usb_printf("f: Find and print free blackbox page\n");
 }
 
 struct settings *settings_get() {

--- a/firmware/src/settings.c
+++ b/firmware/src/settings.c
@@ -24,6 +24,7 @@ void settings_default() {
     settings.motor2          = 0;     // Default disabled
     settings.motor3          = 0;     // Default disabled
     settings.motor4          = 0;     // Default disabled
+    settings.adc_coefficient = 1325; // 1325 for TBS Source One 5" PCB, 1470 for Toadie 3" PCB
     settings.checksum        = 0;
 }
 

--- a/firmware/src/settings.c
+++ b/firmware/src/settings.c
@@ -1,6 +1,7 @@
 #include <stm32g4xx.h>
 #include "settings.h"
 #include "usb.h"
+#include "adc.h"
 
 #define VERSION 2
 
@@ -25,6 +26,11 @@ void settings_default() {
     settings.motor3          = 0;     // Default disabled
     settings.motor4          = 0;     // Default disabled
     settings.adc_coefficient = 1325; // 1325 for TBS Source One 5" PCB, 1470 for Toadie 3" PCB
+    settings.cell_count      = 0;
+    settings.chemistry       = 0;
+    // Remove this if you add another setting; it's just to keep number
+    // of settings even ... see settings.h for more information on this
+    settings.make_this_an_even_number = 0;
     settings.checksum        = 0;
 }
 

--- a/firmware/src/settings.h
+++ b/firmware/src/settings.h
@@ -22,6 +22,13 @@ struct settings {
   uint32_t motor3; // 16
   uint32_t motor4;
   uint32_t adc_coefficient; // 18
+  uint32_t cell_count;
+  uint32_t chemistry; // 20
+  
+  // (Remove if you add another one)
+  uint32_t make_this_an_even_number;
+  // MUST be the last value, and MUST be even
+  uint32_t checksum; // 22
 };
 
 void settings_read();

--- a/firmware/src/settings.h
+++ b/firmware/src/settings.h
@@ -21,7 +21,7 @@ struct settings {
   uint32_t motor2;
   uint32_t motor3; // 16
   uint32_t motor4;
-  uint32_t checksum;
+  uint32_t adc_coefficient; // 18
 };
 
 void settings_read();

--- a/firmware/src/settings.h
+++ b/firmware/src/settings.h
@@ -1,22 +1,25 @@
 #include <stdint.h>
 
+// as an undocumented quirk, the STM32 flash won't save anything unless
+// it has 64 bytes to write. therefore, the number of these settings must
+// be EVEN and each setting must be 32bits long, so e.g. uint32_t...
 struct settings {
   uint32_t version;
-  uint32_t angle_rate;
+  uint32_t angle_rate; // 2
   uint32_t acro_rate;
-  uint32_t p;
+  uint32_t p; // 4
   uint32_t i;
-  uint32_t d;
+  uint32_t d; // 6
   uint32_t yaw_p;
-  uint32_t yaw_i;
+  uint32_t yaw_i; // 8
   uint32_t expo;
-  uint32_t yaw_expo;
+  uint32_t yaw_expo; // 10
   uint32_t throttle_gain;
-  uint32_t throttle_min;
+  uint32_t throttle_min; // 12
   uint32_t motor_direction;
-  uint32_t motor1;
+  uint32_t motor1; // 14
   uint32_t motor2;
-  uint32_t motor3;
+  uint32_t motor3; // 16
   uint32_t motor4;
   uint32_t checksum;
 };

--- a/firmware/src/usb.c
+++ b/firmware/src/usb.c
@@ -252,8 +252,8 @@ void usb_handle_ep1() {
         if(packet[1] == 'd') settings->d = atoi(packet+2);
         if(packet[1] == 'y') settings->yaw_p = atoi(packet+2);
         if(packet[1] == 'Y') settings->yaw_i = atoi(packet+2);
-        if(packet[1] == 't') settings->throttle_gain = atoi(packet+2); // poor man's airmode
-        if(packet[1] == 'T') settings->throttle_min = atoi(packet+2); // idle, basically
+        if(packet[1] == 't') settings->throttle_gain = atoi(packet+2); // max throttle limit
+        if(packet[1] == 'T') settings->throttle_min = atoi(packet+2); // full throttle is the above + this
         if(packet[1] == 'e') settings->expo = atoi(packet+2); // pitch and roll
         if(packet[1] == 'E') settings->yaw_expo = atoi(packet+2);
         if(packet[1] == 'm') { // "motor"
@@ -278,7 +278,7 @@ void usb_handle_ep1() {
         uint16_t page = blackbox_find_free_page();
         usb_printf("Free page: %d\n", page);
       }
-      if(packet[0] == 'h') { // "help, i'm running out of letters"
+      if(packet[0] == 'h') {
         // Dump flash to USB
         dump_flash = blackbox_find_free_page();
       }


### PR DESCRIPTION
- introduce new config settings
- try to guess cell count once at boot unless there is a user setting
- print cell count onto OSD alongside cell voltage
- rename adc_read to adc_read_mV as that's what it does
- some boyscouting