### PR TITLE
Show current as Amperes in OSD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,9 @@ production/
 # SDK / flashing
 STM32Cube
 elf2dfuse
+
+# Foreign files
+*.tar
+*.gz
+*.bz2
+*.dump

--- a/configurator/main.c
+++ b/configurator/main.c
@@ -8,7 +8,8 @@
 #include "usb.h"
 
 void get_all(void) {
-  int value;
+  int value, raw_value;
+
   printf("            TUNING\n");
   value = get_setting(USB_SETTING_CAT_TUNE, USB_SETTING_TUNE_P);
   printf("            P: %d\n", value);
@@ -52,6 +53,13 @@ void get_all(void) {
   printf("    ADC Coeff: %d\n", value);
   value = get_setting(USB_SETTING_CAT_BATT, USB_SETTING_BATT_CELL_COUNT);
   printf("   Cell Count: %d\n", value);
+  value = get_setting(USB_SETTING_CAT_BATT, USB_SETTING_BATT_ADC1_COEFFICIENT);
+  raw_value = get_setting(USB_SETTING_CAT_BATT, USB_VALUE_ADC1_RAW);
+  printf("   ADC1 coeff: %d (current raw value: %d)\n", value, raw_value);
+  value = get_setting(USB_SETTING_CAT_BATT, USB_SETTING_BATT_ADC2_COEFFICIENT);
+  raw_value = get_setting(USB_SETTING_CAT_BATT, USB_VALUE_ADC2_RAW);
+  printf("   ADC2 coeff: %d (current raw value: %d)\n", value, raw_value);
+  printf("(raw value * coefficient / 1000 will give the mV/mA figure)");
 }
 
 int main(int argc, char *argv[])

--- a/configurator/usb.h
+++ b/configurator/usb.h
@@ -29,8 +29,11 @@
 #define USB_SETTING_MOTOR_4         0x04
 #define USB_SETTING_MOTOR_DIRECTION 0x05
 
-#define USB_SETTING_BATT_ADC_COEFFICIENT 0x01
-#define USB_SETTING_BATT_CELL_COUNT      0x02
+#define USB_SETTING_BATT_CELL_COUNT       0x01
+#define USB_SETTING_BATT_ADC1_COEFFICIENT 0x02
+#define USB_VALUE_ADC1_RAW                0x03
+#define USB_SETTING_BATT_ADC2_COEFFICIENT 0x04
+#define USB_VALUE_ADC2_RAW                0x05
 
 int usb_init();
 uint32_t get_setting(uint8_t category, uint8_t index);

--- a/firmware/src/adc.c
+++ b/firmware/src/adc.c
@@ -78,12 +78,15 @@ uint32_t adc_read_mv() {
   volatile struct settings *settings = settings_get();
   uint32_t adc = 0;
   adc = ADC2->DR;
-  if(settings->adc_coefficient == 0) return 0;
-  return adc * settings->adc_coefficient / 1000;
+  if(settings->adc2_coefficient == 0) return 0;
+  return adc * settings->adc2_coefficient / 1000;
 }
 
-// Read ADC1 and return the raw value
-// TODO: This should scale the data to milliamps
+// Read ADC1 and return the value in milliamperes
 uint32_t adc_read_ma() {
- return ADC1->DR;
+  volatile struct settings *settings = settings_get();
+  uint32_t adc = 0;
+  adc = ADC1->DR;
+  if(settings->adc1_coefficient == 0) return 0;
+  return adc * settings->adc2_coefficient / 1000;
 }

--- a/firmware/src/msp.c
+++ b/firmware/src/msp.c
@@ -115,7 +115,7 @@ void send_msp_displayport_write() {
   // Send the write string subcommand
   payload[0] = 3;
   // Near bottom
-  payload[1] = 13;
+  payload[1] = 14;
   // Column
   // (right third on older HDZ VRX firmware)
   payload[2] = 20;
@@ -123,7 +123,9 @@ void send_msp_displayport_write() {
   payload[3] = 0;
   // String
   uint16_t current = adc_read_ma();
-  snprintf((char*)payload+4, 16, "CUR: %05d", current);
+  uint16_t a = current / 1000;
+  uint16_t ma = (current % 1000) / 10; // For 2 decimal places
+  snprintf((char*)payload+4, 16, "%d.%02dA", a, ma);
   // Send the payload
   send_msp(182, payload, 20);
 }

--- a/firmware/src/settings.c
+++ b/firmware/src/settings.c
@@ -8,26 +8,27 @@
 volatile struct settings settings;
 
 void settings_default() {
-  settings.version         = VERSION;
-  settings.angle_rate      = 800;   // 8.0
-  settings.acro_rate       = 800;   // 8.0
-  settings.p               = 100;   // 0.1
-  settings.i               = 200;   // 0.0002
-  settings.d               = 100;   // 0.1
-  settings.yaw_p           = 100;   // 0.1
-  settings.yaw_i           = 200;   // 0.0001
-  settings.expo            = 50;    // 0.5
-  settings.yaw_expo        = 50;    // 0.5
-  settings.throttle_gain   = 80;    // 0.8
-  settings.throttle_min    = 200;   // 200
-  settings.motor_direction = 0;     // Props IN
-  settings.motor1          = 0;     // Default disabled
-  settings.motor2          = 0;     // Default disabled
-  settings.motor3          = 0;     // Default disabled
-  settings.motor4          = 0;     // Default disabled
-  settings.adc_coefficient = 565;   // 565 as calibrated by catphish on v3 board
-  settings.cell_count      = 0;
-  settings.checksum        = 0;
+  settings.version          = VERSION;
+  settings.angle_rate       = 800;   // 8.0
+  settings.acro_rate        = 800;   // 8.0
+  settings.p                = 100;   // 0.1
+  settings.i                = 200;   // 0.0002
+  settings.d                = 100;   // 0.1
+  settings.yaw_p            = 100;   // 0.1
+  settings.yaw_i            = 200;   // 0.0001
+  settings.expo             = 50;    // 0.5
+  settings.yaw_expo         = 50;    // 0.5
+  settings.throttle_gain    = 80;    // 0.8
+  settings.throttle_min     = 200;   // 200
+  settings.motor_direction  = 0;     // Props IN
+  settings.motor1           = 0;     // Default disabled
+  settings.motor2           = 0;     // Default disabled
+  settings.motor3           = 0;     // Default disabled
+  settings.motor4           = 0;     // Default disabled
+  settings.adc1_coefficient = 2150;  // 2150 as calibrated by sixtyfive on v4 board
+  settings.adc2_coefficient = 565;   // 565 as calibrated by catphish on v3 board
+  settings.cell_count       = 0;
+  settings.checksum         = 0;
 }
 
 void settings_read() {

--- a/firmware/src/usb.c
+++ b/firmware/src/usb.c
@@ -216,10 +216,16 @@ void usb_handle_ep1() {
           value = settings->motor4;
         }
       } else if(request[1] == USB_SETTING_CAT_BATT) {
-        if(request[2] == USB_SETTING_BATT_ADC_COEFFICIENT) {
-          value = settings->adc_coefficient;
-        } else if(request[2] == USB_SETTING_BATT_CELL_COUNT) {
+        if(request[2] == USB_SETTING_BATT_CELL_COUNT) {
           value = settings->cell_count;
+        } else if(request[2] == USB_SETTING_BATT_ADC1_COEFFICIENT) {
+          value = settings->adc1_coefficient;
+        } else if(request[2] == USB_VALUE_ADC1_RAW) {
+          value = ADC1->DR;
+        } else if(request[2] == USB_SETTING_BATT_ADC2_COEFFICIENT) {
+          value = settings->adc2_coefficient;
+        } else if(request[2] == USB_VALUE_ADC2_RAW) {
+          value = ADC2->DR;
         }
       }
       response[0] = USB_COMMAND_SETTING_GET;
@@ -271,10 +277,12 @@ void usb_handle_ep1() {
           settings->motor4 = value;
         }
       } else if(request[1] == USB_SETTING_CAT_BATT) {
-        if(request[2] == USB_SETTING_BATT_ADC_COEFFICIENT) {
-          settings->adc_coefficient = value;
-        } else if(request[2] == USB_SETTING_BATT_CELL_COUNT) {
+        if(request[2] == USB_SETTING_BATT_CELL_COUNT) {
           settings->cell_count = value;
+        } else if(request[2] == USB_SETTING_BATT_ADC1_COEFFICIENT) {
+          settings->adc1_coefficient = value;
+        } else if(request[2] == USB_SETTING_BATT_ADC2_COEFFICIENT) {
+          settings->adc2_coefficient = value;
         }
       }
       response[0] = USB_COMMAND_SETTING_SET;


### PR DESCRIPTION
In configurator and firmware:

- change adc_c to adc2_c everywhere
- introduce 2nd coefficient for ADC1
- submit ADC1/2 raw values over USB
- display ADC1/2 raw values in configurator

Also adds ignores for data files in configurator directory.